### PR TITLE
Fix to build from Shenandoah image

### DIFF
--- a/java-shenandoah/8/Dockerfile
+++ b/java-shenandoah/8/Dockerfile
@@ -1,4 +1,4 @@
-FROM        shipilev/openjdk:8
+FROM        shipilev/openjdk-shenandoah:8
 
 LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
 


### PR DESCRIPTION
shipilev/openjdk was no longer packaged with the Shenandoah GC on Java 8. shipilev/openjdk ships with Shenandoah GC starting at Java 11. https://hub.docker.com/r/shipilev/openjdk-shenandoah