### PR TITLE
feat(java): replace openjdk with eclipse emurin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pterodactyl Images
+# Pterodactyl/WISP Docker Images
 
 Docker images that can be used with the Pterodactyl/WISP Game Panel. You can request more images by opening a new issue. These are mostly created for myself.
 
@@ -10,23 +10,19 @@ Navigate to `Admin Panel -> Nests -> Select your egg`. Add Docker image URL(s) f
 
 ![image](https://user-images.githubusercontent.com/10975908/120903180-56719d80-c64d-11eb-8666-02de8ea80701.png)
 
-## Pterodactyl/WISP Images
-
-Add the desired image link from below to your egg using the [instructions from above](https://github.com/Software-Noob/pterodactyl-images#pterodactyl-images).
-
 ### Supported Platforms
 
-| Image           | Supported platforms |
-| --------------- | ------------------- |
-| Java OpenJDK    | AMD64, ARM64        |
-| Java OpenJ9     | AMD64               |
-| Java Shenandoah | AMD64, ARM64        |
-| Java Azul Zulu  | AMD64, ARM64        |
-| Node.js         | AMD64, ARM64        |
-| Python          | AMD64, ARM64        |
-| Sourcemod       | AMD64               |
+| Image                | Supported platforms |
+| -------------------- | ------------------- |
+| Java Azul Zulu       | AMD64, ARM64        |
+| Java Eclipse Temurin | AMD64, ARM64        |
+| Java Shenandoah      | AMD64, ARM64        |
+| Java OpenJ9          | AMD64               |
+| Node.js              | AMD64, ARM64        |
+| Python               | AMD64, ARM64        |
+| Sourcemod            | AMD64               |
 
-### Java OpenJDK [AMD64/ARM64]
+### Java Eclipse Temurin [AMD64/ARM64]
 
 - [Java 8](https://github.com/Software-Noob/pterodactyl-images/tree/main/java/8)
   - `ghcr.io/software-noob/pterodactyl-images:java_8`

--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -1,4 +1,4 @@
-FROM        openjdk:11-slim
+FROM        eclipse-temurin:11
 
 LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
 

--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -1,4 +1,4 @@
-FROM        openjdk:16-slim
+FROM        eclipse-temurin:16
 
 LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
 
@@ -8,9 +8,8 @@ RUN apt-get update -y \
 
 USER        container
 ENV         USER=container HOME=/home/container
-
 WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh
 
-CMD         ["/bin/bash", "/entrypoint.sh"]
+CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -1,4 +1,4 @@
-FROM        openjdk:17-slim
+FROM        eclipse-temurin:17
 
 LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
 
@@ -13,4 +13,4 @@ WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh
 
-CMD         ["/bin/bash", "/entrypoint.sh"]
+CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -1,11 +1,11 @@
-FROM        openjdk:8-slim
+FROM        eclipse-temurin:8
 
 LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
 
 RUN apt-get update -y \
  && apt-get install -y curl ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 \
  && useradd -d /home/container -m container
- 
+
 USER        container
 ENV         USER=container HOME=/home/container
 


### PR DESCRIPTION
openjdk base images have been deprecated

https://github.com/docker-library/openjdk/issues/505