### PR TITLE
fix(java): pin images to focal release for the netty package

### DIFF
--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -1,4 +1,4 @@
-FROM        eclipse-temurin:11
+FROM        eclipse-temurin:11-focal
 
 LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
 
@@ -8,9 +8,8 @@ RUN apt-get update -y \
 
 USER        container
 ENV         USER=container HOME=/home/container
-
 WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh
 
-CMD         ["/bin/bash", "/entrypoint.sh"]
+CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -1,4 +1,4 @@
-FROM        eclipse-temurin:16
+FROM        eclipse-temurin:16-focal
 
 LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
 

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -1,4 +1,4 @@
-FROM        eclipse-temurin:17
+FROM        eclipse-temurin:17-focal
 
 LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
 
@@ -8,7 +8,6 @@ RUN apt-get update -y \
 
 USER        container
 ENV         USER=container HOME=/home/container
-
 WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh

--- a/java/18/Dockerfile
+++ b/java/18/Dockerfile
@@ -1,4 +1,4 @@
-FROM        openjdk:18-slim
+FROM        eclipse-temurin:18-focal
 
 LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
 
@@ -8,9 +8,8 @@ RUN apt-get update -y \
 
 USER        container
 ENV         USER=container HOME=/home/container
-
 WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh
 
-CMD         ["/bin/bash", "/entrypoint.sh"]
+CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -1,4 +1,4 @@
-# must be pinned to older version for Forge support. @see https://github.com/MultiMC/Launcher/issues/4470#issuecomment-1025114255 and https://github.com/McModLauncher/modlauncher/issues/91
+# version must be pinned to older version for Forge support. @see https://github.com/MultiMC/Launcher/issues/4470#issuecomment-1025114255 and https://github.com/McModLauncher/modlauncher/issues/91
 FROM        eclipse-temurin:8u312-b07-jdk-focal
 
 LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
@@ -9,9 +9,8 @@ RUN apt-get update -y \
 
 USER        container
 ENV         USER=container HOME=/home/container
-
 WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh
 
-CMD         ["/bin/bash", "/entrypoint.sh"]
+CMD         [ "/bin/bash", "/entrypoint.sh" ]


### PR DESCRIPTION
Ubuntu Jammy/22.04 netty package and the currently used Mojang netty version are incompatible. Downgrading until a fix is released.

https://github.com/netty/netty/issues/12343

resolves #21