### PR TITLE
feat(java): add graalvm options

### DIFF
--- a/.github/workflows/java-graalvm.yml
+++ b/.github/workflows/java-graalvm.yml
@@ -1,0 +1,56 @@
+name: build java_graalvm
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 17 1,15 * *" # bi-weekly on 1st and 15th calendar day at 17:00
+  push:
+    branches:
+      - main
+    paths:
+      - java-graalvm/**
+
+concurrency:
+  group: java-graalvm-${{ github.ref }}-1
+  cancel-in-progress: true
+
+jobs:
+  build_and_push:
+    name: "java_${{ matrix.tag }}_graalvm"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - 8
+          - 11
+          - 17
+    steps:
+      - name: Git checkout for Github repository workspace
+        uses: actions/checkout@v3
+
+      - name: Setup QEMU for multiarch builds
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: "v0.8.2"
+          buildkitd-flags: --debug
+
+      - name: Login to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v3
+        with:
+          context: ./java-graalvm
+          file: ./java-graalvm/${{ matrix.tag }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/software-noob/pterodactyl-images:java_${{ matrix.tag }}_graalvm

--- a/java-graalvm/11/Dockerfile
+++ b/java-graalvm/11/Dockerfile
@@ -1,0 +1,16 @@
+FROM        ghcr.io/graalvm/jdk:ol8-java11
+
+LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
+
+RUN     microdnf update \
+            && microdnf install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute \
+            && microdnf clean all \
+            && adduser --home-dir /home/container container
+
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+COPY        ./entrypoint.sh /entrypoint.sh
+
+CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java-graalvm/17/Dockerfile
+++ b/java-graalvm/17/Dockerfile
@@ -1,0 +1,16 @@
+FROM        ghcr.io/graalvm/jdk:ol8-java17
+
+LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
+
+RUN     microdnf update \
+            && microdnf install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute \
+            && microdnf clean all \
+            && adduser --home-dir /home/container container
+
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+COPY        ./entrypoint.sh /entrypoint.sh
+
+CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java-graalvm/8/Dockerfile
+++ b/java-graalvm/8/Dockerfile
@@ -1,0 +1,16 @@
+FROM        ghcr.io/graalvm/graalvm-ce:java8
+
+LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
+
+RUN     microdnf update \
+            && microdnf install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute \
+            && microdnf clean all \
+            && adduser --home-dir /home/container container
+
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+COPY        ./entrypoint.sh /entrypoint.sh
+
+CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java-graalvm/entrypoint.sh
+++ b/java-graalvm/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+cd /home/container || exit 1 && echo "Unable to change to /home/container. Something went real wrong."
+
+# Configure colors
+CYAN='\033[0;36m'
+RESET_COLOR='\033[0m'
+
+# Print Current Java Version
+java -version
+
+# Set environment variable that holds the Internal Docker IP
+INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
+export INTERNAL_IP
+
+# Replace Startup Variables
+# shellcheck disable=SC2086
+MODIFIED_STARTUP=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
+echo -e "${CYAN}STARTUP /home/container: ${MODIFIED_STARTUP} ${RESET_COLOR}"
+
+# Run the Server
+# shellcheck disable=SC2086
+eval ${MODIFIED_STARTUP}


### PR DESCRIPTION
Attempt to add GraalVM JDK flavors. Java 8 is graalvm-ce as it's the only maintained version for it. Might look into building from scratch the minimal versions to reduce image size in the future and support multiarch.

This will most likely fail on arm64 right now for java 8.

resolves #6