### PR TITLE
docs:(templates): Add Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATES/bug-report.yml
+++ b/.github/ISSUE_TEMPLATES/bug-report.yml
@@ -1,0 +1,18 @@
+name: 🥚 Bug Report
+description: Something is not working as expected
+title: "[Bug Report]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+          Before opening new issue, make sure there are no existing requests by searching the [repository issues](https://github.com/Software-Noob/pterodactyl-images/issues?q=is%3Aissue+label%3Abug+).
+    validations:
+      required: true
+  - type: textarea
+    id: bug-report
+    attributes:
+      description: Explain the bug with as much information as possible including any error messages. Low effort bug reports will be closed.
+      placeholder: Server crashed after doing X and Y. Error message is ... and previous console output is ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATES/config.yml
+++ b/.github/ISSUE_TEMPLATES/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATES/image-request.yml
+++ b/.github/ISSUE_TEMPLATES/image-request.yml
@@ -1,0 +1,36 @@
+name: 🥚 Image Request
+description: Request a new image or modification to an existing image
+title: "[Image Request]: "
+labels: ["image request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+          Before opening new issue, make sure there are no existing requests by searching the [repository issues](https://github.com/software-noob/pterodactyl-images/issues?q=label%3A%22image+request%22+).
+  - type: dropdown
+    id: expand
+    attributes:
+      label: Does this apply to existing image
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true
+  - type: input
+    id: image-name
+    attributes:
+      label: What's the image for (e.g. NodeJS, Dotnet, Shenandoah, etc)
+      placeholder: NodeJS, Dotnet, Shenandoah, etc
+    validations:
+      required: true
+  - type: textarea
+    id: image-request
+    attributes:
+      label: Image Request
+      description: Provide changes you are proposing
+      placeholder: |
+        The sourcemod image should have X dependency installed for Y plugin that requires it as documented here: https://docs.example.com
+        Example 2
+        New Node version has been released and I would like to have it available in the image
+    validations:
+      required: true


### PR DESCRIPTION
Introduces Github templates with specific input format.

Disables blank issue tempates.