### PR TITLE
feat(sourcemod): backing up and disabling sourcemod

### DIFF
--- a/games/source-sourcemod/entrypoint.sh
+++ b/games/source-sourcemod/entrypoint.sh
@@ -2,20 +2,28 @@
 cd /home/container || exit 1
 sleep 1
 
-CYAN='\033[0;36m'
+BOLD_WHITE='\033[1;37m'
 GREEN='\033[0;32m'
 RED='\033[0;31m'
-YELLOW='\033[1;33m'
+YELLOW='\033[0;33m'
 RESET_COLOR='\033[0m'
 
 # Set environment variable that holds the Internal Docker IP
 INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
 export INTERNAL_IP
 
-# This image allows users to automatically download sourcemod/metamod each time the server starts
-# Egg must have environment variable SOURCEMOD set to a value of 1 or true for this to work
-# Optionally users can specify the sourcemod and metamod versions with the use of SM_VERSION and MM_VERSION egg environment variables
-# Invalid versions will default to the latest stable version, that is currently hard-coded.
+# Available Egg Variables
+
+###################################################################################################################
+# SRCDS_APPID - Steam App ID of the game server (required) (ex: 740)                                              #
+# SRCDS_BETAID - Steam App Beta ID of the game server (optional) (ex: 123456)                                     #
+# SRCDS_BETAPASS - Steam App Beta Password of the game server (optional) (ex: password)                           #
+# SOURCEMOD - Whether to install and update sourcemod/metamod on each startup (optional) (ex: 1, true, false, 0)  #
+# SM_VERSION - Sourcemod version to install (optional) (ex: 1.11) (default: latest)                               #
+# MM_VERSION - Metamod version to install (optional) (ex: 1.11) (default: latest)                                 #
+# INSTALL_PATH - Path to install sourcemod/metamod to (optional) (ex: csgo) (default: csgo)                       #
+###################################################################################################################
+
 
 # Install path defaults to csgo folder. It can be altered with the envrionment variable INSTALL_PATH
 # TODO - Find all default paths for supported games and detect them automatically (tf,dod,css,csgo,etc)
@@ -35,14 +43,13 @@ if [[ -n ${SRCDS_APPID} ]]; then
 fi
 
 # TODO - support specific versions, such as 1.10 6351
-# TODO - backup by moving sourcemod folder when variable is set to 0 or false
 
-# Install SourceMod/Metamod when egg variable SOURCEMOD is 1 or true. Otherwise, skip this step.
+# Install SourceMod/Metamod when egg variable SOURCEMOD is 1 or true. Otherwise, skip the whole step and act as normal server.
 if [[ "${SOURCEMOD}" = 1 || "${SOURCEMOD}" == "true" ]]; then
     mkdir -p /home/container/${INSTALL_PATH}/tmpfiles
     cd /home/container/${INSTALL_PATH}/tmpfiles || exit 1
 
-    echo -e "${YELLOW}SourceMod variable is set to 1. Updating SourceMod/Metamod...${RESET_COLOR}"
+    echo -e "${YELLOW}SourceMod variable is set to 1 or true. Installing SourceMod/Metamod...${RESET_COLOR}"
 
     # Should custom versions be provided, check that they are valid. If not, use latest stable version.
     if [[ -n ${SM_VERSION} ]]; then
@@ -80,7 +87,6 @@ if [[ "${SOURCEMOD}" = 1 || "${SOURCEMOD}" == "true" ]]; then
     # Extract SourceMod and Metamod
     echo "Extracting MM files"
     tar -xf metamod.tar.gz --directory /home/container/${INSTALL_PATH}
-    # check if sourcemod.cfg exists to determine if we need a full install or an update
     if [[ ! -f /home/container/${INSTALL_PATH}/cfg/sourcemod/sourcemod.cfg ]]; then
         echo "Existing sourcemod.cfg not found. Performing full SourceMod install."
         tar -xf sourcemod.tar.gz --directory /home/container/${INSTALL_PATH}
@@ -89,9 +95,15 @@ if [[ "${SOURCEMOD}" = 1 || "${SOURCEMOD}" == "true" ]]; then
         tar -xf sourcemod.tar.gz
         cp -R addons/sourcemod/{bin,extensions,gamedata,translations} ../addons/sourcemod/
     fi
-    echo -e "${GREEN}Done updating Sourcemod/metamod!${RESET_COLOR}"
+    rm -rf "/home/container/${INSTALL_PATH}/tmpfiles"
+    echo -e "${GREEN}Sourcemod/metamod has been installed!${RESET_COLOR}"
+else
+    echo -e "${YELLOW}SourceMod variable is set to false or 0. Skipping SourceMod/Metamod update...${RESET_COLOR}"
 
-    rm -rf /home/container/${INSTALL_PATH}/tmpfiles
+    if [[ -d /home/container/${INSTALL_PATH}/addons/sourcemod ]]; then
+        echo -e "${YELLOW}Sourcemod folder detected. Renaming the folder to disable it.${RESET_COLOR}"
+        mv "/home/container/${INSTALL_PATH}/addons/sourcemod" "/home/container/${INSTALL_PATH}/addons/sourcemod_disabled_$(date +%Y-%m-%d-%H:%M)"
+    fi
 fi
 
 cd /home/container || exit 1
@@ -99,7 +111,9 @@ cd /home/container || exit 1
 # Replace Startup Variables
 # shellcheck disable=SC2086
 MODIFIED_STARTUP=$(eval echo $(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g'))
-echo -e "${CYAN}STARTUP /home/container: ${MODIFIED_STARTUP} ${RESET_COLOR}"
+
+# Display the parsed startup string we're going to execute.
+echo -e "${YELLOW}[Startup Command]: ${BOLD_WHITE} ${MODIFIED_STARTUP} ${RESET_COLOR}"
 
 # Run the Server
 # shellcheck disable=SC2086


### PR DESCRIPTION
Whenever the sourcemod variable is set to false or 0, move the folder by renaming it to disable and back it up.

Fixes #36