### PR TITLE
Add Oracle GraalVM Docker Image

### DIFF
--- a/.github/workflows/java-oracle-graalvm.yml
+++ b/.github/workflows/java-oracle-graalvm.yml
@@ -26,11 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         tag:
-          #- 8
-          #- 11
-          #- 17
+          - 17
           - 21
-          #- 22
+          - 22
     steps:
       - name: Git checkout for Github repository workspace
         uses: actions/checkout@v4
@@ -57,4 +55,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./java-oracle-graalvm/${{ matrix.tag }}/Dockerfile
           push: true
-          tags: ghcr.io/minionguyjpro/pterodactyl-images:java_${{ matrix.tag }}_oracle_graalvm
+          tags: ghcr.io/softwarenoob/pterodactyl-images:java_${{ matrix.tag }}_oracle_graalvm

--- a/.github/workflows/java-oracle-graalvm.yml
+++ b/.github/workflows/java-oracle-graalvm.yml
@@ -1,0 +1,60 @@
+name: build java_oracle_graalvm
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 17 1,15 * *" # bi-weekly on 1st and 15th calendar day at 17:00
+  push:
+    branches:
+      - main
+    paths:
+      - java-oracle-graalvm/**
+
+permissions:
+  actions: read
+  packages: write
+
+concurrency:
+  group: java-oracle-graalvm-${{ github.ref }}-1
+  cancel-in-progress: true
+
+jobs:
+  build_and_push:
+    name: "java_${{ matrix.tag }}_oracle_graalvm"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          #- 8
+          #- 11
+          #- 17
+          - 21
+          #- 22
+    steps:
+      - name: Git checkout for Github repository workspace
+        uses: actions/checkout@v4
+
+      - name: Setup QEMU for multiarch builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
+
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./java-oracle-graalvm
+          platforms: linux/amd64,linux/arm64
+          file: ./java-oracle-graalvm/${{ matrix.tag }}/Dockerfile
+          push: true
+          tags: ghcr.io/Minionguyjpro/pterodactyl-images:java_${{ matrix.tag }}_oracle_graalvm

--- a/.github/workflows/java-oracle-graalvm.yml
+++ b/.github/workflows/java-oracle-graalvm.yml
@@ -55,4 +55,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./java-oracle-graalvm/${{ matrix.tag }}/Dockerfile
           push: true
-          tags: ghcr.io/softwarenoob/pterodactyl-images:java_${{ matrix.tag }}_oracle_graalvm
+          tags: ghcr.io/software-noob/pterodactyl-images:java_${{ matrix.tag }}_oracle_graalvm

--- a/.github/workflows/java-oracle-graalvm.yml
+++ b/.github/workflows/java-oracle-graalvm.yml
@@ -57,4 +57,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./java-oracle-graalvm/${{ matrix.tag }}/Dockerfile
           push: true
-          tags: ghcr.io/Minionguyjpro/pterodactyl-images:java_${{ matrix.tag }}_oracle_graalvm
+          tags: ghcr.io/minionguyjpro/pterodactyl-images:java_${{ matrix.tag }}_oracle_graalvm

--- a/java-oracle-graalvm/17/Dockerfile
+++ b/java-oracle-graalvm/17/Dockerfile
@@ -1,0 +1,21 @@
+FROM        container-registry.oracle.com/graalvm/jdk:17
+
+LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
+LABEL       org.opencontainers.image.source="https://github.com/Software-Noob/pterodactyl-images"
+LABEL       org.opencontainers.image.licenses="MIT"
+
+RUN         microdnf update \
+            && microdnf install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute gcc gcc-c++ freetype libstdc++ lsof glibc-locale-source glibc-langpack-en \
+            && microdnf clean all \
+            && adduser --home-dir /home/container container
+
+ENV         LC_ALL=en_US.UTF-8
+ENV         LANG=en_US.UTF-8
+ENV         LANGUAGE=en_US.UTF-8
+
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+COPY        ./entrypoint.sh /entrypoint.sh
+CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java-oracle-graalvm/21/Dockerfile
+++ b/java-oracle-graalvm/21/Dockerfile
@@ -1,0 +1,21 @@
+FROM        container-registry.oracle.com/graalvm/jdk:21
+
+LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
+LABEL       org.opencontainers.image.source="https://github.com/Software-Noob/pterodactyl-images"
+LABEL       org.opencontainers.image.licenses="MIT"
+
+RUN         microdnf update \
+            && microdnf install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute gcc gcc-c++ freetype libstdc++ lsof glibc-locale-source glibc-langpack-en \
+            && microdnf clean all \
+            && adduser --home-dir /home/container container
+
+ENV         LC_ALL=en_US.UTF-8
+ENV         LANG=en_US.UTF-8
+ENV         LANGUAGE=en_US.UTF-8
+
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+COPY        ./entrypoint.sh /entrypoint.sh
+CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java-oracle-graalvm/22/Dockerfile
+++ b/java-oracle-graalvm/22/Dockerfile
@@ -1,0 +1,21 @@
+FROM        container-registry.oracle.com/graalvm/jdk:22
+
+LABEL       author="Softwarenoob" maintainer="admin@softwarenoob.com"
+LABEL       org.opencontainers.image.source="https://github.com/Software-Noob/pterodactyl-images"
+LABEL       org.opencontainers.image.licenses="MIT"
+
+RUN         microdnf update \
+            && microdnf install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute gcc gcc-c++ freetype libstdc++ lsof glibc-locale-source glibc-langpack-en \
+            && microdnf clean all \
+            && adduser --home-dir /home/container container
+
+ENV         LC_ALL=en_US.UTF-8
+ENV         LANG=en_US.UTF-8
+ENV         LANGUAGE=en_US.UTF-8
+
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+COPY        ./entrypoint.sh /entrypoint.sh
+CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java-oracle-graalvm/entrypoint.sh
+++ b/java-oracle-graalvm/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+cd /home/container || exit 1
+
+# Configure colors
+CYAN='\033[0;36m'
+RESET_COLOR='\033[0m'
+
+# Print Current Java Version
+java -version
+
+# Set environment variable that holds the Internal Docker IP
+INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
+export INTERNAL_IP
+
+# Replace Startup Variables
+# shellcheck disable=SC2086
+MODIFIED_STARTUP=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
+echo -e "${CYAN}STARTUP /home/container: ${MODIFIED_STARTUP} ${RESET_COLOR}"
+
+# Run the Server
+# shellcheck disable=SC2086
+eval ${MODIFIED_STARTUP}


### PR DESCRIPTION
This pull request adds an Oracle GraalVM Docker image, not to be confused with GraalVM (Community Edition/CE) or the now deprecated GraalVM Enterprise Edition/EE from Oracle.